### PR TITLE
Option to set additional headers

### DIFF
--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -125,6 +125,8 @@ class WebSocket extends WebSocketCommon {
 
     public var binaryType:BinaryType;
 
+    public var additionalHeaders(get, null):Map<String, String>;
+
     public function new(uri:String, immediateOpen=true) {
         var uriRegExp = ~/^(\w+?):\/\/([\w\.-]+)(:(\d+))?(\/.*)?$/;
 
@@ -191,6 +193,13 @@ class WebSocket extends WebSocketCommon {
         Log.debug("Thread ended", ws.id);
     }
 
+    function get_additionalHeaders() {
+        if (additionalHeaders == null) {
+            additionalHeaders = new Map<String, String>();
+        }
+        return additionalHeaders;
+    }
+
     public function sendHandshake() {
         var httpRequest = new HttpRequest();
         httpRequest.method = "GET";
@@ -208,6 +217,12 @@ class WebSocket extends WebSocketCommon {
 
         _encodedKey = generateWSKey();
         httpRequest.headers.set(HttpHeader.SEC_WEBSOCKET_KEY, _encodedKey);
+
+        if (additionalHeaders != null) {
+            for ( k in additionalHeaders.keys()) {
+                httpRequest.headers.set(k, additionalHeaders[k]);
+            }
+        }
 
         sendHttpRequest(httpRequest);
     }

--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -244,7 +244,6 @@ class WebSocket extends WebSocketCommon {
     }
 
     private function handshake(httpResponse:HttpResponse) {
-        trace(httpResponse.toString());
         if (httpResponse.code != 101) {
             if (onerror != null) {
                 onerror(httpResponse.headers.get(HttpHeader.X_WEBSOCKET_REJECT_REASON));

--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -6,9 +6,21 @@ import haxe.Constraints.Function;
 import haxe.io.Bytes;
 
 class WebSocket { // lets use composition so we can intercept send / onmessage and convert to something haxey if its binary
+    private var _url:String;
     private var _ws:js.html.WebSocket = null;
 
-    public function new(url:String) {
+    public function new(url:String, immediateOpen=true) {
+        _url = url;
+        if (immediateOpen) {
+            open();
+        }
+    }
+
+    public function open()
+    {
+        if (_ws != null) {
+            throw "Socket already connected";
+        }
         _ws = new js.html.WebSocket(url);
     }
 
@@ -113,7 +125,7 @@ class WebSocket extends WebSocketCommon {
 
     public var binaryType:BinaryType;
 
-    public function new(uri:String) {
+    public function new(uri:String, immediateOpen=true) {
         var uriRegExp = ~/^(\w+?):\/\/([\w\.-]+)(:(\d+))?(\/.*)?$/;
 
         if ( ! uriRegExp.match(uri)) throw 'Uri not matching websocket uri "${uri}"';
@@ -146,6 +158,18 @@ class WebSocket extends WebSocketCommon {
         _uri = uriRegExp.matched(5);
         if (_uri == null || _uri.length == 0) {
             _uri = "/";
+        }
+
+        if (immediateOpen) {
+            open();
+        }
+    }
+
+
+    public function open()
+    {
+        if (state != State.Handshake) {
+            throw "Socket already connected";
         }
         _socket.setBlocking(true);
         _socket.connect(new sys.net.Host(_host), _port);


### PR DESCRIPTION
Adds option to postpone immediate connect upon new(). That enables to set additional headers in supported targets. 

Partialy solves #11, but is IMHO more versatile solution. Setting cookies (and other headers such as custom user agent) can be now done easily without hustle of overriding.

```
var cookies = ["session" => "ABCD"];
var ws = new WebSocket("wss://...", false);
ws.additionalHeaders.set(
    "Cookie",
    [for (k in cookies.keys()) '${k}=${cookies[k]}'].join("; ")
);
ws.open();
```