### PR TITLE
Support for SSL on server

### DIFF
--- a/hx/ws/Buffer.hx
+++ b/hx/ws/Buffer.hx
@@ -156,6 +156,11 @@ class Buffer {
     public function endsWith(e:String):Bool {
         var i = available - e.length;
         var n = currentOffset;
+
+        if (i <= 0) {
+            return false;
+        }
+
         while (i < available) {
             if (peekByte(i) != e.charCodeAt(n)) {
                 return false;

--- a/hx/ws/HttpRequest.hx
+++ b/hx/ws/HttpRequest.hx
@@ -15,7 +15,7 @@ class HttpRequest {
             var parts = line.split(" ");
             method = parts[0];
             uri = parts[1];
-            httpVersion = parts[2];
+            httpVersion = StringTools.trim(parts[2]);
         } else {
             var n = line.indexOf(":");
             var name = line.substr(0, n);

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -29,10 +29,11 @@ class WebSocketCommon {
         id = _nextId++;
         if (socket == null) {
             _socket = new SocketImpl();
-            _socket.setBlocking(false);
         } else {
             _socket = socket;
         }
+        _socket.setBlocking(false);
+        _socket.setTimeout(0);
     }
 
     public function send(data:Any) {

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -310,18 +310,18 @@ class WebSocketCommon {
     }
 
     public function recvHttpRequest():HttpRequest {
-        if (!_buffer.endsWith("\r\n\r\n")) {
+        var response = _buffer.readLinesUntil("\r\n\r\n");
+
+        if (response == null) {
             return null;
         }
 
         var httpRequest = new HttpRequest();
-        while (true) {
-            var line = _buffer.readLine();
+        for (line in response) {
             if (line == null || line == "") {
                 break;
             }
             httpRequest.addLine(line);
-
         }
 
         Log.data(httpRequest.toString(), id);

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -36,12 +36,12 @@ class WebSocketCommon {
     }
 
     public function send(data:Any) {
-        if (Std.is(data, String)) {
+        if (Std.isOfType(data, String)) {
             Log.data(data, id);
             sendFrame(Utf8Encoder.encode(data), OpCode.Text);
-        } else if (Std.is(data, Bytes)) {
+        } else if (Std.isOfType(data, Bytes)) {
             sendFrame(data, OpCode.Binary);
-        } else if (Std.is(data, Buffer)) {
+        } else if (Std.isOfType(data, Buffer)) {
             sendFrame(cast(data, Buffer).readAllAvailableBytes(), OpCode.Binary);
         }
     }
@@ -249,16 +249,16 @@ class WebSocketCommon {
                     #if cs
 
                     needClose = true;
-                    if (Std.is(e, cs.system.io.IOException)) {
+                    if (Std.isOfType(e, cs.system.io.IOException)) {
                         var ioex = cast(e, cs.system.io.IOException);
-                        if (Std.is(ioex.GetBaseException(), cs.system.net.sockets.SocketException)) {
+                        if (Std.isOfType(ioex.GetBaseException(), cs.system.net.sockets.SocketException)) {
                             var sockex = cast(ioex.GetBaseException(), cs.system.net.sockets.SocketException);
                             needClose = !(sockex.SocketErrorCode == cs.system.net.sockets.SocketError.WouldBlock);
                         }
                     }
                     #else
 
-                    needClose = !(e == 'Blocking' || (Std.is(e, Error) && (e:Error).match(Error.Blocked)));
+                    needClose = !(e == 'Blocking' || (Std.isOfType(e, Error) && (e:Error).match(Error.Blocked)));
 
                     #end
                 }

--- a/hx/ws/WebSocketSecureServer.hx
+++ b/hx/ws/WebSocketSecureServer.hx
@@ -1,0 +1,38 @@
+package hx.ws;
+import haxe.Constraints;
+
+import sys.ssl.Key;
+import sys.ssl.Certificate;
+
+@:generic
+class WebSocketSecureServer
+    #if (haxe_ver < 4)
+    <T:(Constructible<SocketImpl->Void>, Handler)>
+    #else
+    <T:Constructible<SocketImpl->Void> & Handler>
+    #end
+    extends WebSocketServer<T> {
+
+    private var _cert:Certificate;
+    private var _key:Key;
+    private var _caChain:Certificate;
+
+    public function new(host:String, port:Int, cert:Certificate, key:Key, caChain:Certificate, maxConnections:Int = 1) {
+        super(host, port, maxConnections);
+
+        _cert=cert;
+        _key=key;
+        _caChain=caChain;
+    }
+
+
+    override private function createSocket() {
+        var socket = new SecureSocketImpl();
+        socket.setHostname(_host);
+
+        socket.setCA(_caChain);
+        socket.setCertificate(_cert, _key);
+        socket.verifyCert = false;
+        return socket;
+    }
+}

--- a/hx/ws/WebSocketServer.hx
+++ b/hx/ws/WebSocketServer.hx
@@ -32,10 +32,14 @@ class WebSocketServer
         _maxConnections = maxConnections;
     }
 
+    private function createSocket() {
+        return new SocketImpl();
+    }
+
     public function start() {
         _stopServer = false;
 
-        _serverSocket = new SocketImpl();
+        _serverSocket = createSocket();
         _serverSocket.setBlocking(false);
         _serverSocket.bind(new sys.net.Host(_host), _port);
         _serverSocket.listen(_maxConnections);

--- a/hx/ws/WebSocketServer.hx
+++ b/hx/ws/WebSocketServer.hx
@@ -66,6 +66,16 @@ class WebSocketServer
         #end
     }
 
+    private function handleNewSocket(socket) {
+        var handler = new T(socket);
+        handlers.push(handler);
+
+        Log.debug("Adding to web server handler to list - total: " + handlers.length, handler.id);
+        if (onClientAdded != null) {
+            onClientAdded(handler);
+        }
+    }
+
     public function tick() {
         if (_stopServer == true) {
             for (h in handlers) {
@@ -81,12 +91,7 @@ class WebSocketServer
         try {
             var clientSocket:SocketImpl = _serverSocket.accept();
             if (clientSocket != null) { // HL doesnt throw blocking, instead returns null
-                var handler = new T(clientSocket);
-                handlers.push(handler);
-                Log.debug("Adding to web server handler to list - total: " + handlers.length, handler.id);
-                if (onClientAdded != null) {
-                    onClientAdded(handler);
-                }
+                handleNewSocket(clientSocket);
             }
         } catch (e:Dynamic) {
             if (e != 'Blocking' && e != Error.Blocked) {


### PR DESCRIPTION
Resolves #29. As side effects compiler no longer complains about deprecated `Std.is`.

`+` various tiny fixes to make our client working with our server, should be according to specs. 

After this, library should be providing full ssl support on both server and client.