### PR TITLE
support for Sec-WebSocket-Protocol

### DIFF
--- a/hx/ws/Handler.hx
+++ b/hx/ws/Handler.hx
@@ -1,6 +1,7 @@
 package hx.ws;
 
 class Handler extends WebSocketCommon {
+    public var validateHandshake:(HttpRequest, HttpResponse) -> HttpResponse = null;
     public function new(socket:SocketImpl) {
         super(socket);
         isClient = false;

--- a/hx/ws/Handler.hx
+++ b/hx/ws/Handler.hx
@@ -1,7 +1,8 @@
 package hx.ws;
 
 class Handler extends WebSocketCommon {
-    public var validateHandshake:(HttpRequest, HttpResponse) -> HttpResponse = null;
+    public var validateHandshake:(HttpRequest, HttpResponse, (HttpResponse) -> Void) -> Void = null;
+
     public function new(socket:SocketImpl) {
         super(socket);
         isClient = false;

--- a/hx/ws/HttpHeader.hx
+++ b/hx/ws/HttpHeader.hx
@@ -4,7 +4,7 @@ class HttpHeader {
     public static inline var SEC_WEBSOCKET_KEY:String = "Sec-WebSocket-Key";
     public static inline var SEC_WEBSOSCKET_ACCEPT:String = "Sec-WebSocket-Accept";
     public static inline var SEC_WEBSOSCKET_VERSION:String = "Sec-WebSocket-Version";
-		public static inline var SEC_WEBSOCKET_PROTOCOL:String = "Sec-WebSocket-Protocol";
+    public static inline var SEC_WEBSOCKET_PROTOCOL:String = "Sec-WebSocket-Protocol";
     public static inline var UPGRADE:String = "Upgrade";
     public static inline var HOST:String = "Host";
     public static inline var CONNECTION:String = "Connection";

--- a/hx/ws/HttpHeader.hx
+++ b/hx/ws/HttpHeader.hx
@@ -4,6 +4,7 @@ class HttpHeader {
     public static inline var SEC_WEBSOCKET_KEY:String = "Sec-WebSocket-Key";
     public static inline var SEC_WEBSOSCKET_ACCEPT:String = "Sec-WebSocket-Accept";
     public static inline var SEC_WEBSOSCKET_VERSION:String = "Sec-WebSocket-Version";
+		public static inline var SEC_WEBSOCKET_PROTOCOL:String = "Sec-WebSocket-Protocol";
     public static inline var UPGRADE:String = "Upgrade";
     public static inline var HOST:String = "Host";
     public static inline var CONNECTION:String = "Connection";

--- a/hx/ws/HttpRequest.hx
+++ b/hx/ws/HttpRequest.hx
@@ -5,10 +5,9 @@ class HttpRequest {
     public var uri:String = null;
     public var httpVersion:String = null;
 
-    public var headers:Map<String, String>;
+    public var headers:Map<String, String> = new Map<String, String>();
 
-    public function new(headers:Map<String, String> = null) {
-        this.headers = headers != null ? headers : new Map<String, String>();
+    public function new() {
     }
 
     public function addLine(line:String) {

--- a/hx/ws/HttpRequest.hx
+++ b/hx/ws/HttpRequest.hx
@@ -5,9 +5,10 @@ class HttpRequest {
     public var uri:String = null;
     public var httpVersion:String = null;
 
-    public var headers:Map<String, String> = new Map<String, String>();
+    public var headers:Map<String, String>;
 
-    public function new() {
+    public function new(headers:Map<String, String> = null) {
+        this.headers = headers != null ? headers : new Map<String, String>();
     }
 
     public function addLine(line:String) {

--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -170,6 +170,8 @@ class WebSocket extends WebSocketCommon {
     public var _host:String;
     public var _port:Int = 0;
     public var _path:String;
+    
+    public var _fullUrl:String;
 
     private var _processThread:Thread;
     private var _encodedKey:String = "wskey";
@@ -190,11 +192,13 @@ class WebSocket extends WebSocketCommon {
 
     inline private function parseUrl(url)
     {
-        var urlRegExp = ~/^(\w+?):\/\/([\w\.-]+)(:(\d+))?(\/.*)?$/;
+        var urlRegExp = ~/^(\w+?):\/\/([\w\.-]+)(:(\d+))?(\/.*)?(\?[=&\w\.-]+)?$/;
 
         if ( ! urlRegExp.match(url)) {
             throw 'Uri not matching websocket URL "${url}"';
         }
+        
+        _fullUrl = url;
 
         _protocol = urlRegExp.matched(1);
 
@@ -209,6 +213,7 @@ class WebSocket extends WebSocketCommon {
             _path = "/";
         }
 
+        _search = urlRegExp.matched(6);
     }
 
     private function createSocket():SocketImpl
@@ -284,7 +289,7 @@ class WebSocket extends WebSocketCommon {
         var httpRequest = new HttpRequest();
         httpRequest.method = "GET";
         // TODO: should propably be hostname+port+path?
-        httpRequest.uri = _path;
+        httpRequest.uri = _fullUrl;
         httpRequest.httpVersion = "HTTP/1.1";
 
         httpRequest.headers.set(HttpHeader.HOST, _host + ":" + _port);

--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -170,6 +170,7 @@ class WebSocket extends WebSocketCommon {
     public var _host:String;
     public var _port:Int = 0;
     public var _path:String;
+    public var _search:String;
     
     public var _fullUrl:String;
 

--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -160,7 +160,9 @@ class WebSocket { // lets use composition so we can intercept send / onmessage a
         }
     }
 }
+
 #elseif sys
+
 #if (haxe_ver >= 4)
 import sys.thread.Thread;
 #elseif neko
@@ -168,6 +170,7 @@ import neko.vm.Thread;
 #elseif cpp
 import cpp.vm.Thread;
 #end
+
 import haxe.crypto.Base64;
 import haxe.io.Bytes;
 

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -259,7 +259,7 @@ class WebSocketCommon {
                     }
                     #else
 
-                    needClose = !(e == 'Blocking' || (Std.isOfType(e, Error) && (e:Error).match(Error.Blocked)) || !(state == Handshake && e == haxe.io.Eof));
+                    needClose = !(e == 'Blocking' || (Std.isOfType(e, Error) && (e:Error).match(Error.Blocked)) || (state == Handshake && e == haxe.io.Eof));
 
                     #end
                 }

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -5,7 +5,6 @@ import haxe.crypto.Base64;
 import haxe.crypto.Sha1;
 import haxe.io.Bytes;
 import haxe.io.Error;
-import hx.ws.Util;
 
 class WebSocketCommon {
     public var id:String;
@@ -25,8 +24,9 @@ class WebSocketCommon {
 
     private var _buffer:Buffer = new Buffer();
 
+    static var _next_id = 0;
     public function new(socket:SocketImpl = null) {
-        id = Util.generateUUID();
+        id = '${_next_id ++}';
         if (socket == null) {
             _socket = new SocketImpl();
         } else {

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -5,6 +5,7 @@ import haxe.crypto.Base64;
 import haxe.crypto.Sha1;
 import haxe.io.Bytes;
 import haxe.io.Error;
+import hx.ws.Util;
 
 class WebSocketCommon {
     public var id:String;
@@ -24,9 +25,8 @@ class WebSocketCommon {
 
     private var _buffer:Buffer = new Buffer();
 
-    static var _next_id = 0;
     public function new(socket:SocketImpl = null) {
-        id = '${_next_id ++}';
+        id = Util.generateUUID();
         if (socket == null) {
             _socket = new SocketImpl();
         } else {

--- a/hx/ws/WebSocketCommon.hx
+++ b/hx/ws/WebSocketCommon.hx
@@ -259,7 +259,7 @@ class WebSocketCommon {
                     }
                     #else
 
-                    needClose = !(e == 'Blocking' || (Std.isOfType(e, Error) && (e:Error).match(Error.Blocked)));
+                    needClose = !(e == 'Blocking' || (Std.isOfType(e, Error) && (e:Error).match(Error.Blocked)) || !(state == Handshake && e == haxe.io.Eof));
 
                     #end
                 }

--- a/hx/ws/WebSocketHandler.hx
+++ b/hx/ws/WebSocketHandler.hx
@@ -73,18 +73,22 @@ class WebSocketHandler extends Handler {
             httpResponse.headers.set(HttpHeader.SEC_WEBSOSCKET_ACCEPT, result);
         }
         
-        if (validateHandshake != null) {
-            httpResponse = validateHandshake(httpRequest, httpResponse) ?? httpResponse;
+        function callback(httpResponse: HttpResponse) {
+            sendHttpResponse(httpResponse);
+
+            if (httpResponse.code == 101) {
+                _onopenCalled = false;
+                state = State.Head;
+                Log.debug('Connected', id);
+            } else {
+                close();
+            }
         }
-
-        sendHttpResponse(httpResponse);
-
-        if (httpResponse.code == 101) {
-            _onopenCalled = false;
-            state = State.Head;
-            Log.debug('Connected', id);
+        
+        if (validateHandshake != null) {
+            validateHandshake(httpRequest, httpResponse, callback);
         } else {
-            close();
+            callback(httpResponse);
         }
     }
 }

--- a/hx/ws/WebSocketHandler.hx
+++ b/hx/ws/WebSocketHandler.hx
@@ -72,6 +72,10 @@ class WebSocketHandler extends Handler {
             httpResponse.headers.set(HttpHeader.CONNECTION, "Upgrade");
             httpResponse.headers.set(HttpHeader.SEC_WEBSOSCKET_ACCEPT, result);
         }
+        
+        if (validateHandshake != null) {
+            httpResponse = validateHandshake(httpRequest, httpResponse) ?? httpResponse;
+        }
 
         sendHttpResponse(httpResponse);
 

--- a/hx/ws/WebSocketServer.hx
+++ b/hx/ws/WebSocketServer.hx
@@ -105,6 +105,7 @@ class WebSocketServer
         #end
     }
 
+    #if (target.threaded)
     private function handlerThread() {
         var handler:T = sys.thread.Thread.readMessage(true);
         while (handler.state != State.Closed) {
@@ -117,6 +118,7 @@ class WebSocketServer
         _serverMutex.release();
         #end
     }
+    #end
     
     public function tick() {
         if (_stopServer == true) {


### PR DESCRIPTION
made it possible to provide an array of protocols when creating a websocket
```haxe
new WebSocket('ws://asdf', false, ['proto1', 'proto2']);
```

it can be accessed and selected by the websocket server using the `validateHandshake` function in the websocket handler:
```haxe
class ProtocolWebSocketHandler extends hx.ws.WebSocketHandler {
	public function new(s:hx.ws.SocketImpl) {
		super(s);
		validateHandshake = (req, resp, callback) -> {
                    var protocols = req.headers.get(hx.ws.HttpHeader.SEC_WEBSOCKET_PROTOCOL);
                    if (!protocols) {
                      callback(resp);
                      return;  
                    }
                    var protocol = protocols.split(',')[0];					 
                    resp.headers.set(hx.ws.HttpHeader.SEC_WEBSOCKET_PROTOCOL, protocol);
                    callback(resp);
                }
        }
}

```

the validateHandshake function can also be used to reject a websocket connection for various reasons


Also made it possible to connect to an address including search params ('ws://connection.com?test=cool`), and added guard to `handleThread` to make it possible to run a websocketserver using hxnodejs.