### PR TITLE
Make sure protocols header is not set to null if there are none defined

### DIFF
--- a/hx/ws/WebSocket.hx
+++ b/hx/ws/WebSocket.hx
@@ -47,6 +47,10 @@ class WebSocket { // lets use composition so we can intercept send / onmessage a
     }
 
     private function createSocket() {
+        if (_protocols == null) {
+            return new js.html.WebSocket(_url);
+        }
+        
         return new js.html.WebSocket(_url, _protocols);
     }
 


### PR DESCRIPTION
It seems like passing `null` to the websocket causes it to set the request header to it, instead of omitting it. This causes errors in some implementations (Chrome fails to connect for example).