### PR TITLE
Replace deprecated use of @:enum

### DIFF
--- a/hx/ws/OpCode.hx
+++ b/hx/ws/OpCode.hx
@@ -1,6 +1,6 @@
 package hx.ws;
 
-@:enum abstract OpCode(Int) {
+enum abstract OpCode(Int) {
     var Continuation = 0x00;
     var Text = 0x01;
     var Binary = 0x02;

--- a/hx/ws/Types.hx
+++ b/hx/ws/Types.hx
@@ -6,7 +6,7 @@ import haxe.io.Bytes;
 typedef BinaryType = js.html.BinaryType;
 #else
 
-@:enum abstract BinaryType(String) {
+enum abstract BinaryType(String) {
     var ARRAYBUFFER = "arraybuffer";
 
     @:to public function toString() {


### PR DESCRIPTION
Compiler would complain about replacing `@:enum` with just `enum` when using the most recent stable version.